### PR TITLE
Add dependency on bartik contrib theme + update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ DKAN's dkan_js_frontend module enabled, and are building
 [DKAN Catalog App](https://github.com/GetDKAN/data-catalog-app) or something derivative
 of that as a decoupled frontend.
 
-Further documentation on this setup coming soon, but this theme will be installed
-if you follow the 
-[DKAN Tools standard project creation process](https://getdkan.github.io/dkan-tools/#newproject.html).
+This theme will currently be installed if you follow the 
+[standard project creation process](https://demo.getdkan.org/modules/contrib/dkan/docs/start.html). 
+However, Bartik has been deprecated in Drupal core, so DKAN is working on an alternative frontend 
+approach going forward.

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,9 @@
     "description": "A Bartik sub-theme that disables libraries on DKAN paths. Use as a template for extending other themes as well.",
     "type": "drupal-theme",
     "license": "GPL-2.0-or-later",
+    "require": {
+        "drupal/bartik": "^1.0"
+    },
     "authors": [
         {
             "name": "Dan Feder",

--- a/dkan_js_frontend_bartik.info.yml
+++ b/dkan_js_frontend_bartik.info.yml
@@ -1,5 +1,7 @@
 name: DKAN Frontend (Bartik)
 type: theme
 description: 'A Bartik sub-theme that disables libraries on DKAN paths. Use as a template for extending other themes as well.'
-core_version_requirement: ^9
+core_version_requirement: ^9.4 || ^10
 base theme: bartik
+dependencies:
+  - drupal:bartik


### PR DESCRIPTION
We may want to coincide this change with adding drupal/bartik as a dependency in the DKAN recommended-project.